### PR TITLE
Escape single quote (') characters as &#39;

### DIFF
--- a/src/Text/Microstache/Render.hs
+++ b/src/Text/Microstache/Render.hs
@@ -306,6 +306,7 @@ renderValue k v = case v of
 escapeHtml :: Text -> Text
 escapeHtml txt = foldr (uncurry T.replace) txt
   [ ("\"", "&quot;")
+  , ("'",  "&#39;")
   , ("<",  "&lt;")
   , (">",  "&gt;")
   , ("&",  "&amp;") ]

--- a/tests/Text/Microstache/RenderSpec.hs
+++ b/tests/Text/Microstache/RenderSpec.hs
@@ -27,7 +27,7 @@ spec = describe "renderMustache" $ do
   let w ns value =
         let template = Template "test" (M.singleton "test" ns)
         in fst (renderMustacheW template value)
-      r ns value = 
+      r ns value =
         let template = Template "test" (M.singleton "test" ns)
         in renderMustache template value
       key = Key . return
@@ -36,8 +36,8 @@ spec = describe "renderMustache" $ do
     r [TextBlock "a text block"] Null `shouldBe` "a text block"
   it "renders escaped variables correctly" $
     r [EscapedVar (key "foo")]
-      (object ["foo" .= ("<html>&\"something\"</html>" :: Text)])
-      `shouldBe` "&lt;html&gt;&amp;&quot;something&quot;&lt;/html&gt;"
+       (object ["foo" .= ("<html>&\"'something'\"</html>" :: Text)])
+      `shouldBe` "&lt;html&gt;&amp;&quot;&#39;something&#39;&quot;&lt;/html&gt;"
   it "renders unescaped variables “as is”" $
     r [UnescapedVar (key "foo")]
       (object ["foo" .= ("<html>&\"something\"</html>" :: Text)])


### PR DESCRIPTION
This backports the upstream change made to `stache` in stackbuilders/stache#36. This fix is necessary to solve a `criterion` bug (bos/criterion#202) in which single quotes are not escaped when substituted into `criterion`'s HTML template, causing browsers to display the report's contents incorrectly.